### PR TITLE
Add containers for jellyfin server and teamspeak

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772569491,
-        "narHash": "sha256-bdr6ueeXO1Xg91sFkuvaysYF0mVdwHBpdyhTjBEWv+s=",
+        "lastModified": 1772633327,
+        "narHash": "sha256-jl+DJB2DUx7EbWLRng+6HNWW/1/VQOnf0NsQB4PlA7I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "924e61f5c2aeab38504028078d7091077744ab17",
+        "rev": "5a75730e6f21ee624cbf86f4915c6e7489c74acc",
         "type": "github"
       },
       "original": {

--- a/hosts/elitebook/default.nix
+++ b/hosts/elitebook/default.nix
@@ -21,7 +21,7 @@
     bottom
     git
     helix
-    jellyfin-media-player
+    # jellyfin-media-player
   ];
 
   mine = {
@@ -32,6 +32,7 @@
       avahi.enable = true;
       niri.enable = true;
       openssh.enable = true;
+      jellyfin-server.enable = true;
       printing.enable = true;
       steam.enable = true;
       tailscale.enable = true;

--- a/hosts/elitebook/default.nix
+++ b/hosts/elitebook/default.nix
@@ -32,7 +32,10 @@
       avahi.enable = true;
       niri.enable = true;
       openssh.enable = true;
-      jellyfin-server.enable = true;
+      jellyfin-server = {
+        enable = true;
+        externalInterface = "wlp0s20f3";
+      };
       printing.enable = true;
       steam.enable = true;
       tailscale.enable = true;

--- a/hosts/elitebook/default.nix
+++ b/hosts/elitebook/default.nix
@@ -27,19 +27,18 @@
   mine = {
     system = {
       hostName = "elitebook";
+      externalInterface = "wlp0s20f3";
+      renderGroupGid = 303;
       fish.enable = true;
       _1password.enable = true;
       avahi.enable = true;
       niri.enable = true;
       openssh.enable = true;
-      jellyfin-server = {
-        enable = true;
-        externalInterface = "wlp0s20f3";
-        renderGroupGid = 303;
-      };
+      jellyfin-server.enable = true;
       printing.enable = true;
       steam.enable = true;
       tailscale.enable = true;
+      teamspeak-client.enable = true;
       teamspeak-server.enable = true;
     };
   };

--- a/hosts/elitebook/default.nix
+++ b/hosts/elitebook/default.nix
@@ -40,6 +40,7 @@
       printing.enable = true;
       steam.enable = true;
       tailscale.enable = true;
+      teamspeak-server.enable = true;
     };
   };
   home-manager.users = {

--- a/hosts/elitebook/default.nix
+++ b/hosts/elitebook/default.nix
@@ -35,6 +35,7 @@
       jellyfin-server = {
         enable = true;
         externalInterface = "wlp0s20f3";
+        renderGroupGid = 303;
       };
       printing.enable = true;
       steam.enable = true;

--- a/hosts/redtruck/default.nix
+++ b/hosts/redtruck/default.nix
@@ -22,7 +22,10 @@
       _1password.enable = true;
       avahi.enable = true;
       docker.enable = true;
-      jellyfin-server.enable = true;
+      jellyfin-server = {
+        enable = true;
+        externalInterface = "enp34s0";
+      };
       makemkv.enable = true;
       niri.enable = true;
       openssh.enable = true;

--- a/hosts/redtruck/default.nix
+++ b/hosts/redtruck/default.nix
@@ -22,6 +22,7 @@
       _1password.enable = true;
       avahi.enable = true;
       docker.enable = true;
+      jellyfin-server.enable = true;
       makemkv.enable = true;
       niri.enable = true;
       openssh.enable = true;

--- a/hosts/redtruck/default.nix
+++ b/hosts/redtruck/default.nix
@@ -18,14 +18,12 @@
   mine = {
     system = {
       hostName = "redtruck";
+      externalInterface = "enp34s0";
       fish.enable = true;
       _1password.enable = true;
       avahi.enable = true;
       docker.enable = true;
-      jellyfin-server = {
-        enable = true;
-        externalInterface = "enp34s0";
-      };
+      jellyfin-server.enable = true;
       makemkv.enable = true;
       niri.enable = true;
       openssh.enable = true;

--- a/hosts/redtruck/default.nix
+++ b/hosts/redtruck/default.nix
@@ -80,6 +80,7 @@
         swayidle.enable = true;
         swaylock.enable = true;
       };
+
       programs = {
         eza.enable = true;
         starship.enable = true;

--- a/modules/_1password/home.nix
+++ b/modules/_1password/home.nix
@@ -24,7 +24,7 @@ in
     mine.user.niri.extraWindowRules = ''
       // Security: Hide 1Password from screencasts/sharing
       window-rule {
-          match app-id="1Password"
+          match app-id="1password"
           block-out-from "screen-capture"
       }
     '';

--- a/modules/jellyfin-server/nixos.nix
+++ b/modules/jellyfin-server/nixos.nix
@@ -1,20 +1,27 @@
 { lib, config, pkgs, ... }:
 {
-  options.mine.system.jellyfin-server.enable = lib.mkEnableOption "Enable Jellyfin-server container";
+  options.mine.system.jellyfin-server = {
+    enable = lib.mkEnableOption "Enable Jellyfin-server container";
+    externalInterface = lib.mkOption {
+      type = lib.types.str;
+      description = "External network interface for NAT";
+    };
+  };
 
   config = lib.mkIf config.mine.system.jellyfin-server.enable {
 
     networking.nat = {
       enable = true;
       internalInterfaces = [ "ve-jellyfin" ];
-      externalInterface = "enp34s0";
+      externalInterface = config.mine.system.jellyfin-server.externalInterface;
     };
 
-    # networking.firewall = {
-    #   checkReversePath = "loose";
-    #   trustedInterfaces = [ "ve-+" ];
-    # };
-    # 
+    system.activationScripts.jellyfin-dirs = ''
+      mkdir -p /srv/media
+      mkdir -p /var/lib/tailscale-jellyfin
+      chmod 755 /srv/media
+      chmod 700 /var/lib/tailscale-jellyfin
+    '';
 
     containers.jellyfin = {
       autoStart = true;
@@ -27,8 +34,6 @@
         { modifier = "rwm"; node = "/dev/net/tun"; }
       ];
 
-      # extraFlags = [ "--property=DeviceAllow=/dev/net/tun" ];
-
       bindMounts = {
         "/media" = {
           hostPath = "/srv/media";
@@ -37,18 +42,24 @@
           hostPath = "/dev/net/tun";
           isReadOnly = false;
         };
-        # "/var/lib/tailscale" = {
-        #   hostPath = "/var/lib/tailscale-jellyfin";
-        #   isReadOnly = false;
-        # };
+        "/var/lib/tailscale" = {
+          hostPath = "/var/lib/tailscale-jellyfin";
+          isReadOnly = false;
+        };
         "/run/tailscale-auth" = {
           hostPath = "/etc/tailscale-jellyfin-key";
           isReadOnly = true;
         };
       };
       config = { config, pkgs, lib, ... }: {
+        systemd.services.tailscaled-autoconnect = {
+          serviceConfig = {
+            Type = lib.mkForce "simple";
+            Restart = "on-failure";
+            RestartSec = 5;
+          };
+        };
 
-        systemd.services.tailscaled-autoconnect.serviceConfig.Type = lib.mkForce "simple";
         services.tailscale = {
           enable = true;
           authKeyFile = "/run/tailscale-auth";
@@ -58,23 +69,31 @@
           ];
         };
 
+        systemd.services.tailscale-serve = {
+          description = "Tailscale Serve for Jellyfin";
+          after = [ "tailscaled-autoconnect.service" "jellyfin.service" ];
+          wants = [ "tailscaled-autoconnect.service" "jellyfin.service" ];
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            Restart = "on-failure";
+            RestartSec = 10;
+          };
+          script = ''
+            ${pkgs.tailscale}/bin/tailscale serve --bg 8096
+          '';
+        };
+
         services.jellyfin.enable = true;
         networking = {
+          nameservers = [ "1.1.1.1" "8.8.8.8" ];
           firewall = {
             enable = true;
-
             trustedInterfaces = [ "tailscale0" ];
-            allowedTCPPorts = [ 8096 ];
             allowedUDPPorts = [ config.services.tailscale.port ];
           };
         };
-
-        # systemd.tmpfiles.rules = [
-        #   "d /var/lib/tailscale-jellyfin 0700 root root -"
-        #   "d /var/lib/nixos-containers/jellyfin/dev/net 0755 root root -"
-        #   "f /var/lib/nixos-containers/jellyfin/dev/net/tun 0666 root root -"
-        #   "d /run/secrets 0700 root root -"
-        # ];
 
         systemd.services.jellyfin = {
           serviceConfig = {

--- a/modules/jellyfin-server/nixos.nix
+++ b/modules/jellyfin-server/nixos.nix
@@ -141,7 +141,7 @@
             authKeyFile = "/run/tailscale-auth";
             extraUpFlags = [
               "--hostname=jellyfintest"
-              "--advertise-tags=tag:media"
+              "--advertise-tags=tag:solo-node"
             ];
           };
 

--- a/modules/jellyfin-server/nixos.nix
+++ b/modules/jellyfin-server/nixos.nix
@@ -6,19 +6,11 @@
 {
   options.mine.system.jellyfin-server = {
     enable = lib.mkEnableOption "Enable Jellyfin-server container";
-    externalInterface = lib.mkOption {
-      type = lib.types.str;
-      description = "External network interface for NAT";
-    };
-    renderGroupGid = lib.mkOption {
-      type = lib.types.int;
-      description = "GID of the render group on the host for GPU passthrough";
-    };
   };
 
   config =
     let
-      renderGid = config.mine.system.jellyfin-server.renderGroupGid;
+      renderGid = config.mine.system.renderGroupGid;
     in
     lib.mkIf config.mine.system.jellyfin-server.enable {
       # ensures nfs will work on any machine
@@ -65,7 +57,7 @@
       networking.nat = {
         enable = true;
         internalInterfaces = [ "ve-jellyfin" ];
-        externalInterface = config.mine.system.jellyfin-server.externalInterface;
+        externalInterface = config.mine.system.externalInterface;
       };
 
       # Make needed directories

--- a/modules/jellyfin-server/nixos.nix
+++ b/modules/jellyfin-server/nixos.nix
@@ -4,52 +4,53 @@
 
   config = lib.mkIf config.mine.system.jellyfin-server.enable {
 
+    networking.nat = {
+      enable = true;
+      internalInterfaces = [ "ve-+" ];
+      externalInterface = "enp34s0";
+    };
 
     containers.jellyfin = {
       autoStart = true;
       privateNetwork = true;
       hostAddress = "192.168.100.10";
       localAddress = "192.168.100.11";
-      # 1. Mount your media from the host into the container securely
-      # bindMounts = {
-      #   "/media/movies" = {
-      #     hostPath = "/mnt/host-nas/movies"; # Change this to your actual host path
-      #     isReadOnly = true; # Hard-locks the directory so the app cannot delete files
-      #   };
-      # };
-
-      config = { config, pkgs, lib, ... }: {
-        services.jellyfin.enable = true;
-        networking.firewall = {
-          enable = true;
-          allowedTCPPorts = [ 8096 ];
+      bindMounts = {
+        "/media" = {
+          hostPath = "/srv/media";
         };
+      };
+      config = { config, pkgs, lib, ... }: {
 
-        # 2. Aggressively sandbox the application via systemd
-        systemd.services.jellyfin = {
-          serviceConfig = {
-            # mkForce overrides the default module to enforce a Ghost User
-            DynamicUser = lib.mkForce true;
-
-            # Systemd will create these folders, let the ghost user own them while running, 
-            # and persist your watch history/database safely across reboots.
-            StateDirectory = "jellyfin";
-            CacheDirectory = "jellyfin";
-
-            ProtectSystem = "strict"; # Mounts the ENTIRE OS read-only to Jellyfin
-            ProtectHome = true; # Completely hides /home and /root directories
-            PrivateTmp = true; # Gives Jellyfin its own isolated, empty /tmp folder
-            PrivateDevices = true; # Hides physical hardware (like /dev/sda) from the app
-            ProtectControlGroups = true; # Prevents the app from tampering with resource limits
-            ProtectKernelTunables = true; # Prevents the app from modifying kernel variables
-            NoNewPrivileges = true; # Blocks the app from escalating privileges (e.g., via sudo)
-
-            # Restrict the type of network sockets the app can open
-            RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" ];
+        services.jellyfin.enable = true;
+        networking = {
+          firewall = {
+            enable = true;
+            allowedTCPPorts = [ 8096 ];
           };
         };
 
-        system.stateVersion = "23.11"; # Update to your current NixOS version
+        systemd.services.jellyfin = {
+          serviceConfig = {
+            DynamicUser = lib.mkForce true;
+
+            StateDirectory = "jellyfin";
+            CacheDirectory = "jellyfin";
+
+            ProtectSystem = lib.mkForce "strict";
+            ProtectHome = lib.mkForce true;
+            PrivateTmp = lib.mkForce true;
+            PrivateDevices = lib.mkForce true;
+            ProtectControlGroups = lib.mkForce true;
+            ProtectKernelTunables = lib.mkForce true;
+            NoNewPrivileges = lib.mkForce true;
+
+            # Restrict the type of network sockets the app can open
+            RestrictAddressFamilies = lib.mkForce [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" ];
+          };
+        };
+
+        system.stateVersion = "24.11"; # Update to your current NixOS version
       };
     };
   };

--- a/modules/jellyfin-server/nixos.nix
+++ b/modules/jellyfin-server/nixos.nix
@@ -4,22 +4,6 @@
 
   config = lib.mkIf config.mine.system.jellyfin-server.enable {
 
-    # systemd.services."container-jellyfin-network" = {
-    #   description = "Bring up ve-jellyfin interface and restart container tailscale";
-    #   after = [ "container@jellyfin.service" ];
-    #   requires = [ "container@jellyfin.service" ];
-    #   wantedBy = [ "multi-user.target" ];
-    #   serviceConfig = {
-    #     Type = "oneshot";
-    #     RemainAfterExit = true;
-    #   };
-    #   script = ''
-    #     ${pkgs.iproute2}/bin/ip link set ve-jellyfin up
-    #     ${pkgs.iproute2}/bin/ip addr add 192.168.100.10/24 dev ve-jellyfin || true
-    #     sleep 2
-    #     ${pkgs.nixos-container}/bin/nixos-container run jellyfin -- systemctl restart tailscaled
-    #   '';
-    # };
     networking.nat = {
       enable = true;
       internalInterfaces = [ "ve-jellyfin" ];
@@ -78,6 +62,8 @@
         networking = {
           firewall = {
             enable = true;
+
+            trustedInterfaces = [ "tailscale0" ];
             allowedTCPPorts = [ 8096 ];
             allowedUDPPorts = [ config.services.tailscale.port ];
           };

--- a/modules/jellyfin-server/nixos.nix
+++ b/modules/jellyfin-server/nixos.nix
@@ -2,7 +2,7 @@
 #   echo "tskey-client-..." | sudo tee /etc/tailscale-jellyfin-key
 #   sudo chmod 600 /etc/tailscale-jellyfin-key
 
-{ lib, config, ... }:
+{ lib, config, pkgs, ... }:
 {
   options.mine.system.jellyfin-server = {
     enable = lib.mkEnableOption "Enable Jellyfin-server container";
@@ -10,162 +10,198 @@
       type = lib.types.str;
       description = "External network interface for NAT";
     };
+    renderGroupGid = lib.mkOption {
+      type = lib.types.int;
+      description = "GID of the render group on the host for GPU passthrough";
+    };
   };
 
-  config = lib.mkIf config.mine.system.jellyfin-server.enable {
-    # ensures nfs will work on any machine
-    boot.supportedFilesystems = [ "nfs" ];
-    services.rpcbind.enable = true;
-    fileSystems = {
-      "/mnt/secure/nas" = {
-        device = "192.168.1.234:/volume1/data";
-        fsType = "nfs";
-        options = [
-          "x-systemd.automount"
-          "noauto"
-          "x-systemd.idle-timeout=600"
-          "nfsvers=3"
-          "soft"
-          "timeo=150"
-          "retrans=2"
-        ];
-      };
-    };
-
-    # host level group id for nfs mount
-    users.groups.media.gid = 65540;
-
-    # Expose app to lan - not needed if only being accessed through tailnet
-    networking.firewall.allowedTCPPorts = [ 8096 ];
-    networking.nat.forwardPorts = [
-      {
-        sourcePort = 8096;
-        destination = "192.168.100.11:8096";
-        proto = "tcp";
-      }
-    ];
-
-    # Allow traffic to enter the container
-    networking.nat = {
-      enable = true;
-      internalInterfaces = [ "ve-jellyfin" ];
-      externalInterface = config.mine.system.jellyfin-server.externalInterface;
-    };
-
-    # Make needed directories
-    system.activationScripts.jellyfin-dirs = ''
-      mkdir -p /var/lib/tailscale-jellyfin
-      chmod 700 /var/lib/tailscale-jellyfin
-    '';
-
-    containers.jellyfin = {
-
-      # Mapping container to a local port
-      autoStart = true;
-      privateNetwork = true;
-      hostAddress = "192.168.100.10";
-      localAddress = "192.168.100.11";
-
-      # tun is needed for tailscale network
-      allowedDevices = [
-        { modifier = "rwm"; node = "/dev/net/tun"; }
-      ];
-
-
-      bindMounts = {
-        "/media" = {
-          hostPath = "/mnt/secure/nas";
-        };
-        # needed for tailscale network
-        "/dev/net/tun" = {
-          hostPath = "/dev/net/tun";
-          isReadOnly = false;
-        };
-        # persists the tailscale node
-        "/var/lib/tailscale" = {
-          hostPath = "/var/lib/tailscale-jellyfin";
-          isReadOnly = false;
-        };
-        # where to find the auth key
-        "/run/tailscale-auth" = {
-          hostPath = "/etc/tailscale-jellyfin-key";
-          isReadOnly = true;
-        };
-      };
-      config = { config, pkgs, lib, ... }: {
-        # container level gid for the media group and nfs mount
-        users.groups.media.gid = 65540;
-
-        systemd.services.tailscaled-autoconnect = {
-          serviceConfig = {
-            # fix for tailscale not creating the veth for the container
-            Type = lib.mkForce "simple";
-            Restart = "on-failure";
-            RestartSec = 5;
-          };
-        };
-
-        # sets the tailscale params
-        services.tailscale = {
-          enable = true;
-          authKeyFile = "/run/tailscale-auth";
-          extraUpFlags = [
-            "--hostname=jellyfintest"
-            "--advertise-tags=tag:media"
+  config =
+    let
+      renderGid = config.mine.system.jellyfin-server.renderGroupGid;
+    in
+    lib.mkIf config.mine.system.jellyfin-server.enable {
+      # ensures nfs will work on any machine
+      boot.supportedFilesystems = [ "nfs" ];
+      services.rpcbind.enable = true;
+      fileSystems = {
+        "/mnt/secure/nas" = {
+          device = "192.168.1.234:/volume1/data";
+          fsType = "nfs";
+          options = [
+            "x-systemd.automount"
+            "noauto"
+            "x-systemd.idle-timeout=600"
+            "nfsvers=3"
+            "soft"
+            "timeo=150"
+            "retrans=2"
           ];
         };
+      };
 
-        # runs tailscale serve once the apps are ready
-        systemd.services.tailscale-serve = {
-          description = "Tailscale Serve for Jellyfin";
-          after = [ "tailscaled-autoconnect.service" "jellyfin.service" ];
-          wants = [ "tailscaled-autoconnect.service" "jellyfin.service" ];
-          wantedBy = [ "multi-user.target" ];
-          serviceConfig = {
-            Type = "oneshot";
-            RemainAfterExit = true;
-            Restart = "on-failure";
-            RestartSec = 10;
+
+      hardware.graphics = {
+        enable = true;
+        extraPackages = [ pkgs.intel-media-driver ];
+      };
+
+      # host level group id for nfs mount
+      users.groups.media.gid = 65540;
+
+      # for hardware acceleration
+      users.groups.render.gid = renderGid;
+      # Expose app to lan - not needed if only being accessed through tailnet
+      networking.firewall.allowedTCPPorts = [ 8096 ];
+      networking.nat.forwardPorts = [
+        {
+          sourcePort = 8096;
+          destination = "192.168.100.11:8096";
+          proto = "tcp";
+        }
+      ];
+
+      # Allow traffic to enter the container
+      networking.nat = {
+        enable = true;
+        internalInterfaces = [ "ve-jellyfin" ];
+        externalInterface = config.mine.system.jellyfin-server.externalInterface;
+      };
+
+      # Make needed directories
+      system.activationScripts.jellyfin-dirs = ''
+        mkdir -p /var/lib/tailscale-jellyfin
+        chmod 700 /var/lib/tailscale-jellyfin
+      '';
+
+      containers.jellyfin = {
+
+        # Mapping container to a local port
+        autoStart = true;
+        privateNetwork = true;
+        hostAddress = "192.168.100.10";
+        localAddress = "192.168.100.11";
+
+        # tun is needed for tailscale network
+        # renderD128 for hardware acceleration
+        allowedDevices = [
+          { modifier = "rwm"; node = "/dev/net/tun"; }
+          { modifier = "rwm"; node = "/dev/dri/renderD128"; }
+        ];
+
+
+        bindMounts = {
+          "/media" = {
+            hostPath = "/mnt/secure/nas";
           };
-          script = ''
-            ${pkgs.tailscale}/bin/tailscale serve --bg 8096
-          '';
+          # needed for tailscale network
+          "/dev/net/tun" = {
+            hostPath = "/dev/net/tun";
+            isReadOnly = false;
+          };
+          # GPU passthrough for hardware acceleration
+          "/dev/dri" = {
+            hostPath = "/dev/dri";
+            isReadOnly = false;
+          }; # persists the tailscale node
+          "/var/lib/tailscale" = {
+            hostPath = "/var/lib/tailscale-jellyfin";
+            isReadOnly = false;
+          };
+          # where to find the auth key
+          "/run/tailscale-auth" = {
+            hostPath = "/etc/tailscale-jellyfin-key";
+            isReadOnly = true;
+          };
         };
+        config = { config, pkgs, lib, ... }: {
+          # container level gid for the media group and nfs mount
+          users.groups.media.gid = 65540;
 
-        services.jellyfin.enable = true;
-        networking = {
-          # needed to get the dns for https nameserver
-          nameservers = [ "1.1.1.1" "8.8.8.8" ];
-          firewall = {
+          hardware.graphics = {
             enable = true;
-            # Lan access
-            allowedTCPPorts = [ 8096 ];
-            # allows connection from other tailscale devices
-            trustedInterfaces = [ "tailscale0" ];
-            allowedUDPPorts = [ config.services.tailscale.port ];
+            extraPackages = [ pkgs.intel-media-driver ];
           };
-        };
 
-        # Hardening the container
-        systemd.services.jellyfin = {
-          serviceConfig = {
-            DynamicUser = lib.mkForce true;
-            # add the service to the media group
-            SupplementaryGroups = [ "media" ];
-            StateDirectory = "jellyfin";
-            CacheDirectory = "jellyfin";
-            ProtectSystem = lib.mkForce "strict";
-            ProtectHome = lib.mkForce true;
-            PrivateTmp = lib.mkForce true;
-            PrivateDevices = lib.mkForce true;
-            ProtectControlGroups = lib.mkForce true;
-            ProtectKernelTunables = lib.mkForce true;
-            NoNewPrivileges = lib.mkForce true;
-            RestrictAddressFamilies = lib.mkForce [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" ];
+          # for hardware acceleration
+          users.groups.render.gid = renderGid;
+          systemd.services.tailscaled-autoconnect = {
+            serviceConfig = {
+              # fix for tailscale not creating the veth for the container
+              Type = lib.mkForce "simple";
+              Restart = "on-failure";
+              RestartSec = 5;
+            };
           };
+
+          # sets the tailscale params
+          services.tailscale = {
+            enable = true;
+            authKeyFile = "/run/tailscale-auth";
+            extraUpFlags = [
+              "--hostname=jellyfintest"
+              "--advertise-tags=tag:media"
+            ];
+          };
+
+          # runs tailscale serve once the apps are ready
+          systemd.services.tailscale-serve = {
+            description = "Tailscale Serve for Jellyfin";
+            after = [ "tailscaled-autoconnect.service" "jellyfin.service" ];
+            wants = [ "tailscaled-autoconnect.service" "jellyfin.service" ];
+            wantedBy = [ "multi-user.target" ];
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              Restart = "on-failure";
+              RestartSec = 10;
+            };
+            script = ''
+              ${pkgs.tailscale}/bin/tailscale serve --bg 8096
+            '';
+          };
+
+          services.jellyfin.enable = true;
+          networking = {
+            # needed to get the dns for https nameserver
+            nameservers = [ "1.1.1.1" "8.8.8.8" ];
+            firewall = {
+              enable = true;
+              # Lan access
+              allowedTCPPorts = [ 8096 ];
+              # allows connection from other tailscale devices
+              trustedInterfaces = [ "tailscale0" ];
+              allowedUDPPorts = [ config.services.tailscale.port ];
+            };
+          };
+
+          # Hardening the container
+          systemd.services.jellyfin = {
+            environment = { LIBVA_DRIVER_NAME = "iHD"; };
+            serviceConfig = {
+              DynamicUser = lib.mkForce true;
+
+              # add the service to the media group
+              SupplementaryGroups = [ "media" "render" ];
+              StateDirectory = "jellyfin";
+              CacheDirectory = "jellyfin";
+              ProtectSystem = lib.mkForce "strict";
+              ProtectHome = lib.mkForce true;
+              PrivateTmp = lib.mkForce true;
+              PrivateDevices = lib.mkForce true;
+              # for hardware acceleration
+              DeviceAllow = [ "/dev/dri/renderD128 rwm" ];
+              BindReadOnlyPaths = [
+                "/run/opengl-driver"
+              ];
+              ProtectControlGroups = lib.mkForce true;
+              ProtectKernelTunables = lib.mkForce true;
+              NoNewPrivileges = lib.mkForce true;
+              RestrictAddressFamilies = lib.mkForce [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" ];
+            };
+          };
+          system.stateVersion = "24.11";
         };
-        system.stateVersion = "24.11";
       };
     };
-  };
 }

--- a/modules/jellyfin-server/nixos.nix
+++ b/modules/jellyfin-server/nixos.nix
@@ -1,0 +1,56 @@
+{ lib, config, ... }:
+{
+  options.mine.system.jellyfin-server.enable = lib.mkEnableOption "Enable Jellyfin-server container";
+
+  config = lib.mkIf config.mine.system.jellyfin-server.enable {
+
+
+    containers.jellyfin = {
+      autoStart = true;
+      privateNetwork = true;
+      hostAddress = "192.168.100.10";
+      localAddress = "192.168.100.11";
+      # 1. Mount your media from the host into the container securely
+      # bindMounts = {
+      #   "/media/movies" = {
+      #     hostPath = "/mnt/host-nas/movies"; # Change this to your actual host path
+      #     isReadOnly = true; # Hard-locks the directory so the app cannot delete files
+      #   };
+      # };
+
+      config = { config, pkgs, lib, ... }: {
+        services.jellyfin.enable = true;
+        networking.firewall = {
+          enable = true;
+          allowedTCPPorts = [ 8096 ];
+        };
+
+        # 2. Aggressively sandbox the application via systemd
+        systemd.services.jellyfin = {
+          serviceConfig = {
+            # mkForce overrides the default module to enforce a Ghost User
+            DynamicUser = lib.mkForce true;
+
+            # Systemd will create these folders, let the ghost user own them while running, 
+            # and persist your watch history/database safely across reboots.
+            StateDirectory = "jellyfin";
+            CacheDirectory = "jellyfin";
+
+            ProtectSystem = "strict"; # Mounts the ENTIRE OS read-only to Jellyfin
+            ProtectHome = true; # Completely hides /home and /root directories
+            PrivateTmp = true; # Gives Jellyfin its own isolated, empty /tmp folder
+            PrivateDevices = true; # Hides physical hardware (like /dev/sda) from the app
+            ProtectControlGroups = true; # Prevents the app from tampering with resource limits
+            ProtectKernelTunables = true; # Prevents the app from modifying kernel variables
+            NoNewPrivileges = true; # Blocks the app from escalating privileges (e.g., via sudo)
+
+            # Restrict the type of network sockets the app can open
+            RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" ];
+          };
+        };
+
+        system.stateVersion = "23.11"; # Update to your current NixOS version
+      };
+    };
+  };
+}

--- a/modules/jellyfin-server/nixos.nix
+++ b/modules/jellyfin-server/nixos.nix
@@ -1,6 +1,6 @@
 # Required: Create the Tailscale OAuth key file before enabling:
-#   echo "tskey-client-..." | sudo tee /etc/tailscale-jellyfin-key
-#   sudo chmod 600 /etc/tailscale-jellyfin-key
+#   echo "tskey-client-..." | sudo tee /etc/tailscale-solo-node-key
+#   sudo chmod 600 /etc/tailscale-solo-node-key
 
 { lib, config, pkgs, ... }:
 {
@@ -115,7 +115,7 @@
           };
           # where to find the auth key
           "/run/tailscale-auth" = {
-            hostPath = "/etc/tailscale-jellyfin-key";
+            hostPath = "/etc/tailscale-solo-node-key";
             isReadOnly = true;
           };
         };

--- a/modules/jellyfin-server/nixos.nix
+++ b/modules/jellyfin-server/nixos.nix
@@ -1,42 +1,100 @@
-{ lib, config, ... }:
+{ lib, config, pkgs, ... }:
 {
   options.mine.system.jellyfin-server.enable = lib.mkEnableOption "Enable Jellyfin-server container";
 
   config = lib.mkIf config.mine.system.jellyfin-server.enable {
 
+    # systemd.services."container-jellyfin-network" = {
+    #   description = "Bring up ve-jellyfin interface and restart container tailscale";
+    #   after = [ "container@jellyfin.service" ];
+    #   requires = [ "container@jellyfin.service" ];
+    #   wantedBy = [ "multi-user.target" ];
+    #   serviceConfig = {
+    #     Type = "oneshot";
+    #     RemainAfterExit = true;
+    #   };
+    #   script = ''
+    #     ${pkgs.iproute2}/bin/ip link set ve-jellyfin up
+    #     ${pkgs.iproute2}/bin/ip addr add 192.168.100.10/24 dev ve-jellyfin || true
+    #     sleep 2
+    #     ${pkgs.nixos-container}/bin/nixos-container run jellyfin -- systemctl restart tailscaled
+    #   '';
+    # };
     networking.nat = {
       enable = true;
-      internalInterfaces = [ "ve-+" ];
+      internalInterfaces = [ "ve-jellyfin" ];
       externalInterface = "enp34s0";
     };
+
+    # networking.firewall = {
+    #   checkReversePath = "loose";
+    #   trustedInterfaces = [ "ve-+" ];
+    # };
+    # 
 
     containers.jellyfin = {
       autoStart = true;
       privateNetwork = true;
       hostAddress = "192.168.100.10";
       localAddress = "192.168.100.11";
+
+
+      allowedDevices = [
+        { modifier = "rwm"; node = "/dev/net/tun"; }
+      ];
+
+      # extraFlags = [ "--property=DeviceAllow=/dev/net/tun" ];
+
       bindMounts = {
         "/media" = {
           hostPath = "/srv/media";
         };
+        "/dev/net/tun" = {
+          hostPath = "/dev/net/tun";
+          isReadOnly = false;
+        };
+        # "/var/lib/tailscale" = {
+        #   hostPath = "/var/lib/tailscale-jellyfin";
+        #   isReadOnly = false;
+        # };
+        "/run/tailscale-auth" = {
+          hostPath = "/etc/tailscale-jellyfin-key";
+          isReadOnly = true;
+        };
       };
       config = { config, pkgs, lib, ... }: {
+
+        systemd.services.tailscaled-autoconnect.serviceConfig.Type = lib.mkForce "simple";
+        services.tailscale = {
+          enable = true;
+          authKeyFile = "/run/tailscale-auth";
+          extraUpFlags = [
+            "--hostname=jellyfintest"
+            "--advertise-tags=tag:media"
+          ];
+        };
 
         services.jellyfin.enable = true;
         networking = {
           firewall = {
             enable = true;
             allowedTCPPorts = [ 8096 ];
+            allowedUDPPorts = [ config.services.tailscale.port ];
           };
         };
+
+        # systemd.tmpfiles.rules = [
+        #   "d /var/lib/tailscale-jellyfin 0700 root root -"
+        #   "d /var/lib/nixos-containers/jellyfin/dev/net 0755 root root -"
+        #   "f /var/lib/nixos-containers/jellyfin/dev/net/tun 0666 root root -"
+        #   "d /run/secrets 0700 root root -"
+        # ];
 
         systemd.services.jellyfin = {
           serviceConfig = {
             DynamicUser = lib.mkForce true;
-
             StateDirectory = "jellyfin";
             CacheDirectory = "jellyfin";
-
             ProtectSystem = lib.mkForce "strict";
             ProtectHome = lib.mkForce true;
             PrivateTmp = lib.mkForce true;
@@ -44,13 +102,10 @@
             ProtectControlGroups = lib.mkForce true;
             ProtectKernelTunables = lib.mkForce true;
             NoNewPrivileges = lib.mkForce true;
-
-            # Restrict the type of network sockets the app can open
             RestrictAddressFamilies = lib.mkForce [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" ];
           };
         };
-
-        system.stateVersion = "24.11"; # Update to your current NixOS version
+        system.stateVersion = "24.11";
       };
     };
   };

--- a/modules/jellyfin-server/nixos.nix
+++ b/modules/jellyfin-server/nixos.nix
@@ -1,4 +1,8 @@
-{ lib, config, pkgs, ... }:
+# Required: Create the Tailscale OAuth key file before enabling:
+#   echo "tskey-client-..." | sudo tee /etc/tailscale-jellyfin-key
+#   sudo chmod 600 /etc/tailscale-jellyfin-key
+
+{ lib, config, ... }:
 {
   options.mine.system.jellyfin-server = {
     enable = lib.mkEnableOption "Enable Jellyfin-server container";
@@ -9,57 +13,99 @@
   };
 
   config = lib.mkIf config.mine.system.jellyfin-server.enable {
+    # ensures nfs will work on any machine
+    boot.supportedFilesystems = [ "nfs" ];
+    services.rpcbind.enable = true;
+    fileSystems = {
+      "/mnt/secure/nas" = {
+        device = "192.168.1.234:/volume1/data";
+        fsType = "nfs";
+        options = [
+          "x-systemd.automount"
+          "noauto"
+          "x-systemd.idle-timeout=600"
+          "nfsvers=3"
+          "soft"
+          "timeo=150"
+          "retrans=2"
+        ];
+      };
+    };
 
+    # host level group id for nfs mount
+    users.groups.media.gid = 65540;
+
+    # Expose app to lan - not needed if only being accessed through tailnet
+    networking.firewall.allowedTCPPorts = [ 8096 ];
+    networking.nat.forwardPorts = [
+      {
+        sourcePort = 8096;
+        destination = "192.168.100.11:8096";
+        proto = "tcp";
+      }
+    ];
+
+    # Allow traffic to enter the container
     networking.nat = {
       enable = true;
       internalInterfaces = [ "ve-jellyfin" ];
       externalInterface = config.mine.system.jellyfin-server.externalInterface;
     };
 
+    # Make needed directories
     system.activationScripts.jellyfin-dirs = ''
-      mkdir -p /srv/media
       mkdir -p /var/lib/tailscale-jellyfin
-      chmod 755 /srv/media
       chmod 700 /var/lib/tailscale-jellyfin
     '';
 
     containers.jellyfin = {
+
+      # Mapping container to a local port
       autoStart = true;
       privateNetwork = true;
       hostAddress = "192.168.100.10";
       localAddress = "192.168.100.11";
 
-
+      # tun is needed for tailscale network
       allowedDevices = [
         { modifier = "rwm"; node = "/dev/net/tun"; }
       ];
 
+
       bindMounts = {
         "/media" = {
-          hostPath = "/srv/media";
+          hostPath = "/mnt/secure/nas";
         };
+        # needed for tailscale network
         "/dev/net/tun" = {
           hostPath = "/dev/net/tun";
           isReadOnly = false;
         };
+        # persists the tailscale node
         "/var/lib/tailscale" = {
           hostPath = "/var/lib/tailscale-jellyfin";
           isReadOnly = false;
         };
+        # where to find the auth key
         "/run/tailscale-auth" = {
           hostPath = "/etc/tailscale-jellyfin-key";
           isReadOnly = true;
         };
       };
       config = { config, pkgs, lib, ... }: {
+        # container level gid for the media group and nfs mount
+        users.groups.media.gid = 65540;
+
         systemd.services.tailscaled-autoconnect = {
           serviceConfig = {
+            # fix for tailscale not creating the veth for the container
             Type = lib.mkForce "simple";
             Restart = "on-failure";
             RestartSec = 5;
           };
         };
 
+        # sets the tailscale params
         services.tailscale = {
           enable = true;
           authKeyFile = "/run/tailscale-auth";
@@ -69,6 +115,7 @@
           ];
         };
 
+        # runs tailscale serve once the apps are ready
         systemd.services.tailscale-serve = {
           description = "Tailscale Serve for Jellyfin";
           after = [ "tailscaled-autoconnect.service" "jellyfin.service" ];
@@ -87,17 +134,24 @@
 
         services.jellyfin.enable = true;
         networking = {
+          # needed to get the dns for https nameserver
           nameservers = [ "1.1.1.1" "8.8.8.8" ];
           firewall = {
             enable = true;
+            # Lan access
+            allowedTCPPorts = [ 8096 ];
+            # allows connection from other tailscale devices
             trustedInterfaces = [ "tailscale0" ];
             allowedUDPPorts = [ config.services.tailscale.port ];
           };
         };
 
+        # Hardening the container
         systemd.services.jellyfin = {
           serviceConfig = {
             DynamicUser = lib.mkForce true;
+            # add the service to the media group
+            SupplementaryGroups = [ "media" ];
             StateDirectory = "jellyfin";
             CacheDirectory = "jellyfin";
             ProtectSystem = lib.mkForce "strict";

--- a/modules/jellyfin-server/nixos.nix
+++ b/modules/jellyfin-server/nixos.nix
@@ -40,10 +40,9 @@
         };
       };
 
-
       hardware.graphics = {
         enable = true;
-        extraPackages = [ pkgs.intel-media-driver ];
+        extraPackages = [ pkgs.intel-media-driver pkgs.vpl-gpu-rt ];
       };
 
       # host level group id for nfs mount
@@ -51,6 +50,7 @@
 
       # for hardware acceleration
       users.groups.render.gid = renderGid;
+
       # Expose app to lan - not needed if only being accessed through tailnet
       networking.firewall.allowedTCPPorts = [ 8096 ];
       networking.nat.forwardPorts = [
@@ -89,7 +89,6 @@
           { modifier = "rwm"; node = "/dev/dri/renderD128"; }
         ];
 
-
         bindMounts = {
           "/media" = {
             hostPath = "/mnt/secure/nas";
@@ -103,7 +102,13 @@
           "/dev/dri" = {
             hostPath = "/dev/dri";
             isReadOnly = false;
-          }; # persists the tailscale node
+          };
+          # GPU drivers from host - avoids duplicating hardware.graphics in container
+          "/run/opengl-driver" = {
+            hostPath = "/run/opengl-driver";
+            isReadOnly = true;
+          };
+          # persists the tailscale node
           "/var/lib/tailscale" = {
             hostPath = "/var/lib/tailscale-jellyfin";
             isReadOnly = false;
@@ -118,13 +123,9 @@
           # container level gid for the media group and nfs mount
           users.groups.media.gid = 65540;
 
-          hardware.graphics = {
-            enable = true;
-            extraPackages = [ pkgs.intel-media-driver ];
-          };
-
           # for hardware acceleration
           users.groups.render.gid = renderGid;
+
           systemd.services.tailscaled-autoconnect = {
             serviceConfig = {
               # fix for tailscale not creating the veth for the container
@@ -180,20 +181,11 @@
             environment = { LIBVA_DRIVER_NAME = "iHD"; };
             serviceConfig = {
               DynamicUser = lib.mkForce true;
-
-              # add the service to the media group
               SupplementaryGroups = [ "media" "render" ];
               StateDirectory = "jellyfin";
               CacheDirectory = "jellyfin";
-              ProtectSystem = lib.mkForce "strict";
               ProtectHome = lib.mkForce true;
               PrivateTmp = lib.mkForce true;
-              PrivateDevices = lib.mkForce true;
-              # for hardware acceleration
-              DeviceAllow = [ "/dev/dri/renderD128 rwm" ];
-              BindReadOnlyPaths = [
-                "/run/opengl-driver"
-              ];
               ProtectControlGroups = lib.mkForce true;
               ProtectKernelTunables = lib.mkForce true;
               NoNewPrivileges = lib.mkForce true;

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -14,6 +14,7 @@
     ./system/nixos.nix
     ./tailscale/nixos.nix
     ./teamspeak-client/nixos.nix
+    ./teamspeak-server/nixos.nix
     ./unfree
     ./users/nixos.nix
   ];

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -5,6 +5,7 @@
     ./docker/nixos.nix
     ./fish/nixos.nix
     ./gamescope/nixos.nix
+    ./jellyfin-server/nixos.nix
     ./makemkv/nixos.nix
     ./niri/nixos.nix
     ./openssh/nixos.nix

--- a/modules/system/nixos.nix
+++ b/modules/system/nixos.nix
@@ -15,6 +15,16 @@ in
       type = types.str;
       description = "The hostname";
     };
+    externalInterface = mkOption {
+      type = lib.types.nullOr lib.types.str;
+      description = "External network interface for container NAT";
+      default = null;
+    };
+    renderGroupGid = mkOption {
+      type = lib.types.nullOr lib.types.int;
+      description = "GID of the render group on the host for GPU passthrough";
+      default = null;
+    };
   };
 
   config = mkMerge [

--- a/modules/teamspeak-server/nixos.nix
+++ b/modules/teamspeak-server/nixos.nix
@@ -2,13 +2,9 @@
 #   echo "tskey-client-..." | sudo tee /etc/tailscale-solo-node-key
 #   sudo chmod 600 /etc/tailscale-solo-node-key
 #
-# Note: teamspeak-server is unfree, ensure your nixpkgs config allows it:
-#   nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
-#     "teamspeak-server"
-#   ];
-#
 # First login: check /var/log/teamspeak3-server inside the container
 # for the ServerAdmin privilege key.
+# sudo nixos-container run teamspeak-server -- cat /var/log/teamspeak3-server | grep serveradmin
 
 { lib, config, ... }:
 {

--- a/modules/teamspeak-server/nixos.nix
+++ b/modules/teamspeak-server/nixos.nix
@@ -2,9 +2,8 @@
 #   echo "tskey-client-..." | sudo tee /etc/tailscale-solo-node-key
 #   sudo chmod 600 /etc/tailscale-solo-node-key
 #
-# First login: check /var/log/teamspeak3-server inside the container
-# for the ServerAdmin privilege key.
-# sudo nixos-container run teamspeak-server -- cat /var/log/teamspeak3-server | grep serveradmin
+# First login get the ServerAdmin privilege key.
+# sudo nixos-container run teamspeak -- journalctl -u teamspeak3-server --no-page | grep token
 
 { lib, config, ... }:
 {
@@ -13,15 +12,18 @@
   };
 
   config = lib.mkIf config.mine.system.teamspeak-server.enable {
-    mine.allowedUnfree = [
-      "teamspeak-server"
-    ];
-
     # Make needed directories
     system.activationScripts.teamspeak-dirs = ''
       mkdir -p /var/lib/tailscale-teamspeak
       chmod 700 /var/lib/tailscale-teamspeak
     '';
+
+
+    networking.nat = {
+      enable = true;
+      internalInterfaces = [ "ve-teamspeak" ];
+      externalInterface = config.mine.system.externalInterface;
+    };
 
     containers.teamspeak = {
 
@@ -54,6 +56,9 @@
       };
 
       config = { config, lib, ... }: {
+        nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
+          "teamspeak-server"
+        ];
 
         systemd.services.tailscaled-autoconnect = {
           serviceConfig = {
@@ -92,6 +97,7 @@
             DynamicUser = lib.mkForce true;
             StateDirectory = "teamspeak3-server";
             CacheDirectory = "teamspeak3-server";
+            LogsDirectory = "teamspeak3-server";
             ProtectHome = lib.mkForce true;
             PrivateTmp = lib.mkForce true;
             ProtectControlGroups = lib.mkForce true;

--- a/modules/teamspeak-server/nixos.nix
+++ b/modules/teamspeak-server/nixos.nix
@@ -1,0 +1,109 @@
+# Required: Create the Tailscale OAuth key file before enabling:
+#   echo "tskey-client-..." | sudo tee /etc/tailscale-teamspeak-key
+#   sudo chmod 600 /etc/tailscale-teamspeak-key
+#
+# Note: teamspeak-server is unfree, ensure your nixpkgs config allows it:
+#   nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
+#     "teamspeak-server"
+#   ];
+#
+# First login: check /var/log/teamspeak3-server inside the container
+# for the ServerAdmin privilege key.
+
+{ lib, config, ... }:
+{
+  options.mine.system.teamspeak-server = {
+    enable = lib.mkEnableOption "Enable TeamSpeak server container";
+  };
+
+  config = lib.mkIf config.mine.system.teamspeak-server.enable {
+
+    # Make needed directories
+    system.activationScripts.teamspeak-dirs = ''
+      mkdir -p /var/lib/tailscale-teamspeak
+      chmod 700 /var/lib/tailscale-teamspeak
+    '';
+
+    containers.teamspeak = {
+
+      autoStart = true;
+      privateNetwork = true;
+      hostAddress = "192.168.100.12";
+      localAddress = "192.168.100.13";
+
+      # tun is needed for tailscale network
+      allowedDevices = [
+        { modifier = "rwm"; node = "/dev/net/tun"; }
+      ];
+
+      bindMounts = {
+        # needed for tailscale network
+        "/dev/net/tun" = {
+          hostPath = "/dev/net/tun";
+          isReadOnly = false;
+        };
+        # persists the tailscale node
+        "/var/lib/tailscale" = {
+          hostPath = "/var/lib/tailscale-teamspeak";
+          isReadOnly = false;
+        };
+        # where to find the auth key
+        "/run/tailscale-auth" = {
+          hostPath = "/etc/tailscale-teamspeak-key";
+          isReadOnly = true;
+        };
+      };
+
+      config = { config, pkgs, lib, ... }: {
+
+        systemd.services.tailscaled-autoconnect = {
+          serviceConfig = {
+            # fix for tailscale not creating the veth for the container
+            Type = lib.mkForce "simple";
+            Restart = "on-failure";
+            RestartSec = 5;
+          };
+        };
+
+        # sets the tailscale params
+        services.tailscale = {
+          enable = true;
+          authKeyFile = "/run/tailscale-auth";
+          extraUpFlags = [
+            "--hostname=teamspeaktest"
+            "--advertise-tags=tag:container"
+          ];
+        };
+
+        services.teamspeak3.enable = true;
+
+        networking = {
+          nameservers = [ "1.1.1.1" "8.8.8.8" ];
+          firewall = {
+            enable = true;
+            # allows connection from other tailscale devices
+            trustedInterfaces = [ "tailscale0" ];
+            allowedUDPPorts = [ config.services.tailscale.port ];
+          };
+        };
+
+        # Hardening the container
+        systemd.services.teamspeak3-server = {
+          serviceConfig = {
+            DynamicUser = lib.mkForce true;
+            StateDirectory = "teamspeak3-server";
+            CacheDirectory = "teamspeak3-server";
+            ProtectHome = lib.mkForce true;
+            PrivateTmp = lib.mkForce true;
+            ProtectControlGroups = lib.mkForce true;
+            ProtectKernelTunables = lib.mkForce true;
+            NoNewPrivileges = lib.mkForce true;
+            RestrictAddressFamilies = lib.mkForce [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" ];
+          };
+        };
+
+        system.stateVersion = "24.11";
+      };
+    };
+  };
+}

--- a/modules/teamspeak-server/nixos.nix
+++ b/modules/teamspeak-server/nixos.nix
@@ -1,6 +1,6 @@
 # Required: Create the Tailscale OAuth key file before enabling:
-#   echo "tskey-client-..." | sudo tee /etc/tailscale-teamspeak-key
-#   sudo chmod 600 /etc/tailscale-teamspeak-key
+#   echo "tskey-client-..." | sudo tee /etc/tailscale-solo-node-key
+#   sudo chmod 600 /etc/tailscale-solo-node-key
 #
 # Note: teamspeak-server is unfree, ensure your nixpkgs config allows it:
 #   nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
@@ -17,6 +17,9 @@
   };
 
   config = lib.mkIf config.mine.system.teamspeak-server.enable {
+    mine.allowedUnfree = [
+      "teamspeak-server"
+    ];
 
     # Make needed directories
     system.activationScripts.teamspeak-dirs = ''
@@ -49,7 +52,7 @@
         };
         # where to find the auth key
         "/run/tailscale-auth" = {
-          hostPath = "/etc/tailscale-teamspeak-key";
+          hostPath = "/etc/tailscale-solo-node-key";
           isReadOnly = true;
         };
       };

--- a/modules/teamspeak-server/nixos.nix
+++ b/modules/teamspeak-server/nixos.nix
@@ -57,7 +57,7 @@
         };
       };
 
-      config = { config, pkgs, lib, ... }: {
+      config = { config, lib, ... }: {
 
         systemd.services.tailscaled-autoconnect = {
           serviceConfig = {
@@ -74,7 +74,7 @@
           authKeyFile = "/run/tailscale-auth";
           extraUpFlags = [
             "--hostname=teamspeaktest"
-            "--advertise-tags=tag:container"
+            "--advertise-tags=tag:solo-node"
           ];
         };
 


### PR DESCRIPTION
- **jellyfin server container added**
- **jellyfin working**
- **tailscale node and container working**
- **update default for elite**
- **tailscale and jelly working**
- **nfs mounts working**
- **commit before removing protections**
- **jellyfin-server working**
- **adding teamspeak server**
- **change to solo-node-key**
- **update to use solo node key**
- **use solo node**
- **teamspeak and jelly servers working as intended**
